### PR TITLE
Fix bug in split-ellipses mode

### DIFF
--- a/src/CommitMessageFormatter.ts
+++ b/src/CommitMessageFormatter.ts
@@ -151,10 +151,10 @@ class CommitMessageFormatter {
     }
 
     if (this._subjectMode === 'split-ellipses') {
-      const firstLine = rawText.split('\n')[0];
-      const words = firstLine.split(' ');
+      const words = subjectLine.split(' ');
+      const rest = rawText.substring(subjectLine.length + 1);
       let formatted = '';
-      let rest = '';
+      let subjectRest = '';
 
       words.forEach((word, i) => {
         const prefix = i > 0 ? ' ' : '';
@@ -164,22 +164,24 @@ class CommitMessageFormatter {
         if (
           formatted.length + wordPadded.length + ellipsis.length <=
             this._subjectLength &&
-          rest === ''
+          subjectRest === ''
         ) {
           formatted += wordPadded;
         } else {
-          if (rest === '') {
+          if (subjectRest === '') {
             formatted += ellipsis;
-            rest += ellipsis + word;
+            subjectRest += ellipsis + word;
           } else {
-            rest += ' ' + word;
+            subjectRest += ' ' + word;
           }
         }
       });
 
+      const restPadded = rest.length > 0 ? '\n\n' + rest : rest;
+
       return {
         formatted,
-        rest,
+        rest: subjectRest + restPadded,
       };
     }
 

--- a/test/CommitMessageFormatter.test.ts
+++ b/test/CommitMessageFormatter.test.ts
@@ -284,4 +284,34 @@ Praesent convallis leo quis eros laoreet, nec viverra nulla ultricies.
 
     expect(actual).toBe(expected);
   });
+
+  it('Subject mode split-ellipses preserves body', () => {
+    const raw = trim`
+Phasellus ac nisi ac arcu blandit egestas ac non dui.
+Etiam sed lorem id mauris posuere porta id at lacus.
+Aenean gravida nulla at tempor lobortis.
+Fusce rhoncus tellus nec nisl congue bibendum.
+Praesent convallis leo quis eros laoreet, nec viverra nulla ultricies.
+`;
+
+    const expected = trim`
+Phasellus ac nisi ac arcu blandit egestas ac...
+
+...non dui.
+
+Etiam sed lorem id mauris posuere porta id at lacus. Aenean gravida
+nulla at tempor lobortis. Fusce rhoncus tellus nec nisl congue bibendum.
+Praesent convallis leo quis eros laoreet, nec viverra nulla ultricies.
+`;
+
+    const formatter = new CommitMessageFormatter({
+      lineLength: 72,
+      subjectLength: 50,
+      collapseMultipleEmptyLines: false,
+      subjectMode: 'split-ellipses',
+    });
+    const actual = formatter.format(raw);
+
+    expect(actual).toBe(expected);
+  });
 });


### PR DESCRIPTION
The body was disappeared after formatting.

Modeled after commit ca5c27049e880210d1bfb2a0ec8098892722f303, which fixed the same issue for split mode.

If and when these changes reach https://github.com/bendera/vscode-commit-message-formatter, I believe the changes should fix https://github.com/bendera/vscode-commit-message-formatter/issues/3.

Note: To be fully transparent, I did not figure out how to build the extension or run its tests. What I _did_ do is try my best to make equivalent changes to CommitMessageFormatter.js in my installed copy of the extension. I then used the modified extension to format the "raw" text of the added test case and manually verified that it resulted in the "expected" text.